### PR TITLE
update open-webui to 6.27.0

### DIFF
--- a/services/open-webui/6.27.0/defaults/cm.yaml
+++ b/services/open-webui/6.27.0/defaults/cm.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: open-webui-6.27.0-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ingress:
+      enabled: false
+    service:
+      type: LoadBalancer
+    ollama:
+      ollama:
+        gpu:
+          enabled: true
+        models:
+          pull:
+            - mistral

--- a/services/open-webui/6.27.0/defaults/kustomization.yaml
+++ b/services/open-webui/6.27.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/open-webui/6.27.0/helmrelease.yaml
+++ b/services/open-webui/6.27.0/helmrelease.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: open-webui
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: open-webui
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: open-webui
+        namespace: ${releaseNamespace}
+      version: 6.27.0
+  interval: 1m0s
+  install:
+    createNamespace: true
+    crds: CreateReplace
+  targetNamespace: open-webui
+  releaseName: open-webui
+  valuesFrom:
+    - kind: ConfigMap
+      name: open-webui-6.27.0-defaults
+    - kind: ConfigMap
+      name: open-webui-overrides
+      optional: true

--- a/services/open-webui/6.27.0/kustomization.yaml
+++ b/services/open-webui/6.27.0/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - ../../../helm-repositories/helm.openwebui.com/helm.openwebui.com.yaml


### PR DESCRIPTION
This pull request introduces configuration and deployment files for the `open-webui` service version 6.27.0. The changes include defining a ConfigMap, setting up HelmRelease specifications, and configuring Kustomize resources for deployment.

### Configuration Setup:

* [`services/open-webui/6.27.0/defaults/cm.yaml`](diffhunk://#diff-533ebbd7a7acba9fb573d76dcfa44938d48a9ff0a2151013411b2f70695febadR1-R19): Added a ConfigMap to define default values for the `open-webui` service, including settings for ingress, service type, and GPU-enabled model pulling.

### HelmRelease Deployment:

* [`services/open-webui/6.27.0/helmrelease.yaml`](diffhunk://#diff-bee1db1ead136048ae8d60877da89132f1954b800028a5b88b92735fe7c1ece3R1-R28): Added a HelmRelease resource to manage the deployment of the `open-webui` chart, specifying the chart version, namespace, and values sources from ConfigMaps.

### Kustomize Resources:

* [`services/open-webui/6.27.0/defaults/kustomization.yaml`](diffhunk://#diff-9b5f8912047e37793b23fc4ef4b134d6f67af55082b69996f33b0025a1889f7cR1-R5): Added a Kustomization file to include the `cm.yaml` ConfigMap as a resource.
* [`services/open-webui/6.27.0/kustomization.yaml`](diffhunk://#diff-a4237d4a5e850c0a7e923372604ce65583563c3641c266b90ef178cf6aba89e0R1-R5): Added a Kustomization file to include the `helmrelease.yaml` resource and a reference to the Helm repository configuration.