### PR TITLE
update openwebui to v6.29.0

### DIFF
--- a/services/open-webui/6.29.0/defaults/cm.yaml
+++ b/services/open-webui/6.29.0/defaults/cm.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: open-webui-6.29.0-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ingress:
+      enabled: false
+    service:
+      type: LoadBalancer
+    ollama:
+      ollama:
+        gpu:
+          enabled: true
+        models:
+          pull:
+            - mistral

--- a/services/open-webui/6.29.0/defaults/kustomization.yaml
+++ b/services/open-webui/6.29.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/open-webui/6.29.0/helmrelease.yaml
+++ b/services/open-webui/6.29.0/helmrelease.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: open-webui
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: open-webui
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: open-webui
+        namespace: ${releaseNamespace}
+      version: 6.29.0
+  interval: 1m0s
+  install:
+    createNamespace: true
+    crds: CreateReplace
+  targetNamespace: open-webui
+  releaseName: open-webui
+  valuesFrom:
+    - kind: ConfigMap
+      name: open-webui-6.29.0-defaults
+    - kind: ConfigMap
+      name: open-webui-overrides
+      optional: true

--- a/services/open-webui/6.29.0/kustomization.yaml
+++ b/services/open-webui/6.29.0/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - ../../../helm-repositories/helm.openwebui.com/helm.openwebui.com.yaml


### PR DESCRIPTION
This pull request introduces configuration files to deploy and manage version 6.29.0 of the `open-webui` service using Kubernetes and Helm. The changes include setting up default configurations, defining a HelmRelease resource, and integrating the deployment with Kustomize. Below are the most important changes grouped by theme:

### Configuration Setup:
* Added a `ConfigMap` file (`cm.yaml`) to define default values for the `open-webui` service, such as disabling ingress by default, setting the service type to `LoadBalancer`, and enabling GPU support for the `ollama` component with the `mistral` model.

### HelmRelease Definition:
* Created a `HelmRelease` resource (`helmrelease.yaml`) to manage the deployment of the `open-webui` service. It specifies the chart version, namespace creation, CRD handling, and references to the default and optional override `ConfigMap` configurations.

### Kustomize Integration:
* Added a `kustomization.yaml` file to include the `helmrelease.yaml` and a Helm repository configuration file for the `open-webui` service. This facilitates deployment orchestration using Kustomize.
* Created a separate `kustomization.yaml` file to reference the `cm.yaml` configuration file, enabling modular management of resources.