### PR TITLE
add renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        ":dependencyDashboard"
+    ],
+    "flux": {
+        "managerFilePatterns": [
+            "services/**/*.yaml"
+        ]
+    },
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "services/infisical/.*/defaults/cm\\.yaml$"
+            ],
+            "matchStrings": [
+                "repository:\\s*(?<depName>infisical/infisical)\\s*\\n\\s*tag:\\s*\"(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+-postgres)\""
+            ],
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
+        }
+    ],
+    "packageRules": [
+        {
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "infisical/infisical"
+            ],
+            "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+-postgres$/"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request introduces a new `renovate.json` configuration file to automate dependency updates using Renovate. The configuration includes standard settings, custom rules for managing dependencies, and specific patterns for handling Docker images.

### Renovate configuration setup:

* Added a `$schema` reference to validate the `renovate.json` file against the Renovate schema.
* Extended the configuration with `config:recommended` and enabled the dependency dashboard (`:dependencyDashboard`).

### Custom dependency management:

* Defined `managerFilePatterns` under the `flux` section to target YAML files in the `services` directory.
* Added a custom manager to handle `infisical/infisical` Docker images by matching specific file patterns and extracting version information using regex.

### Package rules:

* Created a rule to allow only specific versions of the `infisical/infisical` Docker image that match the regex pattern `v<MAJOR>.<MINOR>.<PATCH>-postgres`.