### PR TITLE
update infisical to 0.144.0

### DIFF
--- a/services/infisical/0.144.0/dashboard.yaml
+++ b/services/infisical/0.144.0/dashboard.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    kommander.d2iq.io/application: infisical
+  name: infisical-dashboard-info
+  namespace: infisical-system
+data:
+  dashboardLink: https://infisical.${ingressAddress}/
+  docsLink: https://infisical.com/docs/
+  name: infisical
+  version: "0.144.0"

--- a/services/infisical/0.144.0/defaults/cm.yaml
+++ b/services/infisical/0.144.0/defaults/cm.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: infisical-0.144.0-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    infisical:
+      image:
+        repository: infisical/infisical
+        tag: "v0.144.0-postgres"
+        pullPolicy: IfNotPresent

--- a/services/infisical/0.144.0/defaults/kustomization.yaml
+++ b/services/infisical/0.144.0/defaults/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/infisical/0.144.0/helmrelease.yaml
+++ b/services/infisical/0.144.0/helmrelease.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: infisical
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: infisical-standalone
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: infisical
+        namespace: ${releaseNamespace}
+      version: 1.6.1
+  interval: 1m0s
+  install:
+    createNamespace: true
+    crds: CreateReplace
+  targetNamespace: infisical-system
+  releaseName: infisical
+  valuesFrom:
+    - kind: ConfigMap
+      name: infisical-0.144.0-defaults
+    - kind: ConfigMap
+      name: infisical-overrides
+      optional: true

--- a/services/infisical/0.144.0/kustomization.yaml
+++ b/services/infisical/0.144.0/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - ../../../helm-repositories/dl.cloudsmith.io
+  - dashboard.yaml


### PR DESCRIPTION
This pull request introduces configuration files for deploying version `0.144.0` of the Infisical service. The changes include setting up necessary Kubernetes resources, default configurations, and HelmRelease specifications for managing the deployment.

### Deployment Configuration:

* Added `dashboard.yaml` to define a `ConfigMap` with metadata and links for the Infisical dashboard, including the dashboard URL and documentation link. (`[services/infisical/0.144.0/dashboard.yamlR1-R12](diffhunk://#diff-9e5840a4dbf5185a76fa7bfbb1d623e77b2b0fefb936dcee12e4a243dbb81484R1-R12)`)
* Added `cm.yaml` to define a `ConfigMap` containing default values for the Infisical deployment, such as the image repository, tag, and pull policy. (`[services/infisical/0.144.0/defaults/cm.yamlR1-R13](diffhunk://#diff-d74fb8f723549d5259f697c3023878068946f0e9c415fdf272279e64364017a1R1-R13)`)
* Added `kustomization.yaml` to include the `cm.yaml` resource in the configuration. (`[services/infisical/0.144.0/defaults/kustomization.yamlR1-R5](diffhunk://#diff-7758ed09a2d499e1826c7a1a46e6bfdb1d9a5f2f8e93be93de7c76cae9f5aa9dR1-R5)`)

### HelmRelease Management:

* Added `helmrelease.yaml` to define a `HelmRelease` for deploying the Infisical service, specifying the Helm chart, version, namespace, and configuration sources. (`[services/infisical/0.144.0/helmrelease.yamlR1-R28](diffhunk://#diff-ec5ac5f718aedb3bdd3547562e28350d5bde0db2f1b7b8d1225572d1eb6449ffR1-R28)`)
* Updated the top-level `kustomization.yaml` to include the `helmrelease.yaml` and other necessary resources for the deployment. (`[services/infisical/0.144.0/kustomization.yamlR1-R6](diffhunk://#diff-5d119d156384b5e787524fcb292d6dd2dd701375715b67b23506c509ec47b82fR1-R6)`)